### PR TITLE
upset R package compatibility

### DIFF
--- a/intervene/intervene
+++ b/intervene/intervene
@@ -177,14 +177,7 @@ def main():
     upset_parser.add_argument('--sbcolor', type=str, default='#317eab', 
                   help='Color of set size bar plot. '
                        'Default is: "%(default)s".\n\n')
-
-    upset_parser.add_argument('--mblabel', type=str, default='No. of Intersections', 
-                  help='The y-axis label of the intersection size bars. '
-                       'Default is: "%(default)s".\n\n')
-    upset_parser.add_argument('--sxlabel', type=str, default='Set size', 
-                  help='The x-axis label of the set size bars. '
-                       'Default is: "%(default)s".\n\n')
-           
+          
     upset_parser.add_argument('--figtype', dest="figtype",choices=('pdf','svg','ps','tiff','png'), 
                    default='pdf',help='Figure type for the plot. '
                        'e.g. --figtype svg. Default is "%(default)s"\n\n')    

--- a/intervene/modules/upset/upset.py
+++ b/intervene/modules/upset/upset.py
@@ -195,7 +195,7 @@ def create_r_script(labels, names, options):
     else:
         options.showzero = "'on'"
 
-    temp_f.write('upset(fromExpression(expressionInput), nsets='+str(len(key))+', nintersects='+str(options.ninter)+', show.numbers="'+str(options.showsize)+'", main.bar.color="'+options.mbcolor+'", sets.bar.color="'+options.sbcolor+'", empty.intersections='+str(options.showzero)+', order.by = "'+options.order+'", number.angles = 0, mainbar.y.label ="'+options.mblabel+'", sets.x.label ="'+options.sxlabel+'")\n')
+    temp_f.write('upset(fromExpression(expressionInput), nsets='+str(len(key))+', nintersects='+str(options.ninter)+', show.numbers="'+str(options.showsize)+'", main.bar.color="'+options.mbcolor+'", sets.bar.color="'+options.sbcolor+'", empty.intersections='+str(options.showzero)+', order.by = "'+options.order+'", number.angles = 0)\n')
     temp_f.write('invisible(dev.off())\n')
 
     #print temp_f.read()


### PR DESCRIPTION
In the R upset package installed in the bioconda/quay repository, the options `mainbar.y.label` and `sets.x.label` do not exist, causing a failure:

```
$ intervene upset --names A,B,C -o . -i $a $b $c

Running UpSet module. Please wait...

Error in upset(fromExpression(expressionInput), nsets = 3, nintersects = 30,  :
  unused arguments (mainbar.y.label = "No. of Intersections", sets.x.label = "Set size")
Execution halted

You are done! Please check your results @ ..
Thank you for using Intervene!

```
This removes those options, which allows it to proceed